### PR TITLE
adds new send-text option, comments, and readme example

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -52,11 +52,15 @@ Options:
         -o              : Only run once, don't scroll forever.
         -c<RRGGBB>      : Text color as hex (default: FFFFFF)
         -b<RRGGBB>      : Background color as hex (default: 000000)
+        -v              : Scroll text vertically 
 ```
 
 Sample
 ```bash
 ./send-text -f fonts/6x10.bdf "We ♥ Flaschen Taschen"
+
+# Or coordinated horizontal and vertical messages
+./send-text -h localhost "♥Flaschen" -f fonts/5x5.bdf -s 60 -g 45x35+0+15+15 & ./send-text -h localhost "Taschen " -f fonts/5x5.bdf  -v  -s 60 -g 45x35+20+0+15 && fg
 
 # Or, how about showing the time
 while : ; do sleep 1 ; ./send-text -f fonts/9x18.bdf -s0 `date +%H:%M` ; done

--- a/client/README.md
+++ b/client/README.md
@@ -60,7 +60,7 @@ Sample
 ./send-text -f fonts/6x10.bdf "We ♥ Flaschen Taschen"
 
 # Or coordinated horizontal and vertical messages
-./send-text -h localhost "♥Flaschen" -f fonts/5x5.bdf -s 60 -g 45x35+0+15+15 & ./send-text -h localhost "Taschen " -f fonts/5x5.bdf  -v  -s 60 -g 45x35+20+0+15 && fg
+./send-text -h localhost "♥Flaschen" -f fonts/5x5.bdf -s 60 -g 45x35+0+15+3 & ./send-text -h localhost "Taschen " -f fonts/5x5.bdf  -v  -s 60 -g 45x35+20+0+2 && fg
 
 # Or, how about showing the time
 while : ; do sleep 1 ; ./send-text -f fonts/9x18.bdf -s0 `date +%H:%M` ; done

--- a/client/bdf-font.cc
+++ b/client/bdf-font.cc
@@ -150,4 +150,16 @@ int DrawText(FlaschenTaschen *c, const Font &font,
     return x - start_x;
 }
 
+int VerticalDrawText(FlaschenTaschen *c, const Font &font,
+             int x, int y, const Color &color, const Color *background_color,
+             const char *utf8_text) {
+    const int start_y = y;
+    while (*utf8_text) {
+        const uint32_t cp = utf8_next_codepoint(utf8_text);
+        font.DrawGlyph(c, x, y, color, background_color, cp);
+	y += font.height() ;
+    }
+    return y - start_y;
+}
+
 }  // namespace ft

--- a/client/bdf-font.cc
+++ b/client/bdf-font.cc
@@ -157,7 +157,7 @@ int VerticalDrawText(FlaschenTaschen *c, const Font &font,
     while (*utf8_text) {
         const uint32_t cp = utf8_next_codepoint(utf8_text);
         font.DrawGlyph(c, x, y, color, background_color, cp);
-	y += font.height() ;
+        y += font.height() ;
     }
     return y - start_y;
 }

--- a/client/bdf-font.h
+++ b/client/bdf-font.h
@@ -66,6 +66,14 @@ int DrawText(FlaschenTaschen *c, const Font &font, int x, int y,
              const Color &color, const Color *background_color,
              const char *utf8_text);
 
+// Draw text as above, but vertically, encoded in UTF-8, with given "font" at
+// "x","y" with "color".
+// "background_color" can be NULL for transparency.
+// The "y" position is the baseline of the font.
+// Returns font height to advance up on the screen.
+int VerticalDrawText(FlaschenTaschen *c, const Font &font, int x, int y,
+             const Color &color, const Color *background_color,
+             const char *utf8_text);
 }  // namespace ft
 
 #endif  // RPI_GRAPHICS_H

--- a/client/send-text.cc
+++ b/client/send-text.cc
@@ -216,7 +216,7 @@ int main(int argc, char *argv[]) {
         }
         else {
           display.Fill(bg);
-          VerticalDrawText(&display, font, x_pos, height + font.height() ,fg, &bg, text);
+          VerticalDrawText(&display, font, x_pos, -1 + font.height() ,fg, &bg, text);
           display.Send();
         }
     }

--- a/client/send-text.cc
+++ b/client/send-text.cc
@@ -28,7 +28,7 @@
 
 #define DEFAULT_WIDTH 45
 #define DEFAULT_HEIGHT 35
-#define WIDEST_GLYPH 'Z'
+#define WIDEST_GLYPH 'W'
 
 volatile bool interrupt_received = false;
 static void InterruptHandler(int signo) {

--- a/client/send-text.cc
+++ b/client/send-text.cc
@@ -175,7 +175,7 @@ int main(int argc, char *argv[]) {
     const int x_pos = (width - font.CharacterWidth(WIDEST_GLYPH)) / 2 ;
 
     // dry-run to determine total number of pixels.
-    const int total_height = DrawText(&display, font, 0, y_pos, fg, NULL, text);
+    const int total_height = VerticalDrawText(&display, font, 0, y_pos, fg, NULL, text);
     const int total_width = strlen(text) * font.height();
 
     // if rotated, center in in the available display space.
@@ -200,7 +200,7 @@ int main(int argc, char *argv[]) {
             do {
               display.Fill(bg);
               for (int s = 0; s < total_height + height && !interrupt_received; ++s) {
-                  VerticalDrawText(&display, font, x_pos, height - s, fg, &bg, text);
+                  VerticalDrawText(&display, font, x_pos, height + font.height() - s, fg, &bg, text);
                   display.Send();
                   usleep(scroll_delay_ms * 1000);
                }

--- a/client/send-text.cc
+++ b/client/send-text.cc
@@ -175,8 +175,8 @@ int main(int argc, char *argv[]) {
     const int x_pos = (width - font.CharacterWidth(WIDEST_GLYPH)) / 2 ;
 
     // dry-run to determine total number of pixels.
-       const int total_height = DrawText(&display, font, 0, y_pos, fg, NULL, text);
-       const int total_width = strlen(text) * font.height();
+    const int total_height = DrawText(&display, font, 0, y_pos, fg, NULL, text);
+    const int total_width = strlen(text) * font.height();
 
     // if rotated, center in in the available display space.
 


### PR DESCRIPTION
enables bannery style text scrolling
- VerticalDrawText() scrolls text from bottom to top
- use CharacterWidth of 'W' from bdf-font for font width, does not assume
  flaschen taschen dimensions
