### PR TITLE
Fix recvfrom on Mac OS.

### DIFF
--- a/client/game-engine.cc
+++ b/client/game-engine.cc
@@ -89,7 +89,8 @@ int UDPInputController::RegisterPlayers(UDPFlaschenTaschen *display,
                  "1. Player");
     display->Send();
 
-    if (recvfrom(fd_, NULL, 0,
+    char c;
+    if (recvfrom(fd_, &c, 1,
                  0, (struct sockaddr *) &client_address,
                  &address_length) < 0) {
         return 0;
@@ -107,7 +108,7 @@ int UDPInputController::RegisterPlayers(UDPFlaschenTaschen *display,
         if (interrupt_received) {
             return 0;
         }
-        if (recvfrom(fd_, NULL, 0,
+        if (recvfrom(fd_, &c, 1,
                      0, (struct sockaddr *) &client_address,
                      &address_length) < 0) {
             return 1;


### PR DESCRIPTION
On Mac OS, recvfrom(NULL, 0) returns immediately, which breaks the game engine
logic. recvfrom(&c, 1) instead, which blocks until the first message.
