### PR TITLE
Fix API makefile for Darwin based systems

### DIFF
--- a/api/lib/Makefile
+++ b/api/lib/Makefile
@@ -2,6 +2,11 @@ CXXFLAGS=-Wall -Wextra -O3 -I../include -I. -std=c++03
 LIB_OBJECTS=udp-flaschen-taschen.o bdf-font.o graphics.o
 LIB_CXXFLAGS=$(CXXFLAGS) -fPIC
 
+SONAME = -soname
+ifeq ($(shell uname -s),Darwin)
+	SONAME = -install_name
+endif
+
 TARGET=libftclient
 
 all : $(TARGET).a $(TARGET).so.1
@@ -10,7 +15,7 @@ $(TARGET).a: $(LIB_OBJECTS)
 	ar rcs $@ $^
 
 $(TARGET).so.1 : $(LIB_OBJECTS)
-	g++ -shared -Wl,-soname,$@ -o $@ $^
+	g++ -shared -Wl,$(SONAME),$@ -o $@ $^
 
 %.o : %.cc
 	$(CXX) $(LIB_CXXFLAGS) -c -o $@ $<


### PR DESCRIPTION
Hey @hzeller, first of all thanks for creating and maintaining this project, it is of great use and I already learnt a lot by playing around with it.

I found a small issue when trying to compile sample projects depending on `./api/lib`: On MacOS (and I assume every other Darwin based system), `-soname` is an unknown `g++` flag, which can be replaced by `-install_name`.

Unfortunately I am not a g++/make crack. I anyway hope my proposed change should fix this issue without any side effects.

Many thanks for looking into it.