### PR TITLE
Add an array interface to Flaschen.

### DIFF
--- a/api/python/flaschen.py
+++ b/api/python/flaschen.py
@@ -45,6 +45,21 @@ class Flaschen(object):
     self._data[-1 * len(footer):] = footer
     self._header_len = len(header)
 
+  @property
+  def __array_interface__(self):
+    '''An array interface to directly access the framebuffer pixel data.
+    
+    Direct writes to pixel data will ignore the transparent parameter.
+    '''
+    return {
+      "shape": (self.height, self.width, 3),
+      "typestr": "|u1",
+      "data": memoryview(self._data)[
+        self._header_len : self._header_len + (self.height * self.width * 3)
+      ],
+      "version": 3,
+    }
+
   def set(self, x, y, color):
     '''Set the pixel at the given coordinates to the specified color.
 


### PR DESCRIPTION
Allows Numpy to be used to read and write pixel data to the framebuffer.  This is faster than setting `self._data` directly and allows all features of Numpy to be used while not adding a dependency on Numpy.

Example:
```py
import flaschen
import numpy as np

ft = flaschen.Flaschen(UDP_IP, UDP_PORT, 45, 35)
pixels = np.asarray(ft)
pixels[1, :] = (255, 0, 0)  # Set 2nd row to red.
pixels[:, 1] = (0, 255, 0)  # Set 2nd column to green.
pixels[(pixels == (0, 0, 0)).all(axis=-1)] = (1, 1, 1)  # Change all (0, 0, 0) pixels to (1, 1, 1).
ft.send()
```