### PR TITLE
Setup a Flit package for the Python API.

### DIFF
--- a/api/python/README.md
+++ b/api/python/README.md
@@ -1,0 +1,5 @@
+To install this package for Python open a terminal in this directory and then run the command:
+```
+pip install .
+```
+You can now use `import flaschen` in your Python scripts.

--- a/api/python/flaschen.py
+++ b/api/python/flaschen.py
@@ -11,8 +11,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://gnu.org/licenses/gpl-2.0.txt>
+'''A Python API client for Flaschen Taschen.'''
 
 import socket
+
+__version__ = "0.1.0"
 
 # Netpbm header with Flaschen Taschen offset included.
 _HEADER_P6_FT = b"""\

--- a/api/python/pyproject.toml
+++ b/api/python/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "flaschen"
+authors = [{ name = "Henner Zeller", email = "h.zeller@acm.org" }]
+license = { file = "../../LICENSE" }
+classifiers = [
+    "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+]
+dynamic = ["version", "description"]
+
+[project.urls]
+Home = "https://github.com/hzeller/flaschen-taschen"


### PR DESCRIPTION
This provides a standard way to install the script.  Flit is chosen since the script is small and portable, this can be changed later if needed.

Reading the [Flit docs](https://flit.pypa.io/en/latest/) is recommended, but the usage for end users will be to do a standard Pip install as shown in the new readme.  Publishing to PyPI might be a good idea, but isn't required.

This also means you don't need force the import search path for the Python examples unless you really want to.  Running `pip install -e .` will install a development build where changes to the script are reflected in the next import.