### PR TITLE
Add send_array method to the Python API.

### DIFF
--- a/api/python/flaschen.py
+++ b/api/python/flaschen.py
@@ -56,11 +56,15 @@ class Flaschen(object):
     self.transparent = transparent
     self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     self._sock.connect((host, port))
-    header = _HEADER_P6 % {b"width": self.width, b"height": self.height}
-    footer = _FOOTER_FT % {b"x": 0, b"y": 0, b"z": self.layer}
-    self._data = bytearray(width * height * 3 + len(header) + len(footer))
+    header = _HEADER_P6_FT % {
+      b"width": self.width,
+      b"height": self.height,
+      b"x": 0,
+      b"y": 0,
+      b"z": self.layer,
+    }
+    self._data = bytearray(width * height * 3 + len(header))
     self._data[0:len(header)] = header
-    self._data[-1 * len(footer):] = footer
     self._header_len = len(header)
 
   @property

--- a/api/python/flaschen.py
+++ b/api/python/flaschen.py
@@ -14,20 +14,6 @@
 
 import socket
 
-# Netpbm raw RGB header.
-_HEADER_P6 = b"""\
-P6
-%(width)d %(height)d
-255
-"""
-
-# Flaschen Taschen footer holding the offset.
-_FOOTER_FT = b"""\
-%(x)d
-%(y)d
-%(z)d
-"""
-
 # Netpbm header with Flaschen Taschen offset included.
 _HEADER_P6_FT = b"""\
 P6

--- a/api/python/flaschen.py
+++ b/api/python/flaschen.py
@@ -63,7 +63,7 @@ class Flaschen(object):
       b"y": 0,
       b"z": self.layer,
     }
-    self._data = bytearray(width * height * 3 + len(header))
+    self._data = bytearray(len(header) + (width * height * 3))
     self._data[0:len(header)] = header
     self._header_len = len(header)
 


### PR DESCRIPTION
This method allows sending pixel data with arbitrary offsets and sizes.  It seemed odd that the API couldn't do this before.  This bypasses the initial parameters given to `Flaschen`, with the size derived from the array and the offset/layer given directly.

Numpy is required to call the new method, but you can still import the module without it.

I refactored the header and footer strings. These are no longer ever non-bytes, so conversions are no longer needed.  I've also added the alternative header protocol with the offset inline so that I can skip the footer.

Example:
```py
import flaschen
import numpy as np

ft = flaschen.Flaschen(UDP_IP, UDP_PORT, transparent=False)  # Width and height parameters are now optional.
pixels = np.zeros((35, 45, 3), dtype=np.uint8)
pixels[1, :] = (255, 0, 0)  # Set 2nd row to red.
pixels[:, 1] = (0, 255, 0)  # Set 2nd column to green.
ft.send_array(pixels, offset=(0, 0, 5))  # Unlike the array interface, this respects transparent.
```
Performance is expected to be a little slower than the array interface, but still much faster than the previous methods.

After this there isn't much more I can think of doing without dropping Python 2 support.  Otherwise I'd add full type annotations.