### PR TITLE
Fix Python example to support Python 3.

### DIFF
--- a/examples-api-use/simple-example.py
+++ b/examples-api-use/simple-example.py
@@ -7,8 +7,8 @@ UDP_PORT = 1337
 ft = flaschen.Flaschen(UDP_IP, UDP_PORT, 45, 35)
 
 while True:
-  for b in xrange(0, 256):
-    for y in xrange(0, ft.height):
-      for x in xrange(0, ft.width):
-        ft.set(x, y, ((x * 255) / 45, (y * 255) / 35, b))
+  for b in range(0, 256):
+    for y in range(0, ft.height):
+      for x in range(0, ft.width):
+        ft.set(x, y, ((x * 255) // 45, (y * 255) // 35, b))
     ft.send()


### PR DESCRIPTION
`xrange` replaced with `range`.  You should generally avoid `xrange` in the future.

Division operators have been replaced with floor division with will behave the same in Python 2/3.

I didn't do this but I could replace the example with Numpy, which will run faster (maybe too fast) but is usually less readable:
```py
while True:
  pixels = np.asarray(ft)
  for b in range(0, 256):
    pixels[:, :, 0] = np.linspace(0, 255, num=ft.width, dtype=np.uint8)
    pixels[:, :, 1] = np.linspace(0, 255, num=ft.height, dtype=np.uint8)[:, np.newaxis]
    pixels[:, :, 2] = b
    ft.send()
```