### PR TITLE
ft-server startup script for init.d

### DIFF
--- a/doc/starting-on-boot-initd.md
+++ b/doc/starting-on-boot-initd.md
@@ -1,0 +1,21 @@
+## What is this?
+
+After installing flaschen-taschen on your machine, you can start it on boot by creating an init.d script.
+
+An example for that script lives under `init.d/flaschen-taschen-server`.
+
+## Installation
+1. Copy the script: `cp init.d/flaschen-taschen-server /etc/init.d/`
+2. Make it executable: `chmod +x /etc/init.d/flaschen-taschen-server`
+3. Add it to the boot sequence: `update-rc.d flaschen-taschen-server defaults`
+
+## Usage - like any other service
+1. Start the service: `service flaschen-taschen-server start`
+2. Stop the service: `service flaschen-taschen-server stop`
+3. Restart the service: `service flaschen-taschen-server restart`
+
+## What about the demos?
+
+The demos live under a separate repo, https://github.com/cgorringe/ft-demos
+
+Instructions for running the demos are in that repo, including an init.d script for starting the demos on boot.

--- a/init.d/flaschen-taschen-server
+++ b/init.d/flaschen-taschen-server
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Provides:		ft-server
+# Required-Start:	udev $remote_fs $all
+# Required-Stop:	$remote_fs
+# Should-Start:
+# Should-Stop:
+# Default-Start:	4 5
+# Default-Stop:		0 6
+# Short-Description:	Start ft-server after boot and kill it on shutdown
+### END INIT INFO
+
+FT_HOME="/home/noisebridge/code/flaschen-taschen"
+FT_SERVER="${FT_HOME}/server"
+PATH="/sbin:/bin:/usr/sbin:/usr/bin:${FT_SERVER}"
+NAME="ft-server"
+DESC="Flaschen-taschen server"
+
+DAEMON="${FT_SERVER}/${NAME}"
+DAEMON_OPTS=""
+RUN_AS_USER="root"
+
+# Get lsb functions
+. /lib/lsb/init-functions
+
+test -x "${DAEMON}" || exit 0
+
+if [ -r "/etc/default/${NAME}" ]
+then
+	. "/etc/default/${NAME}"
+fi
+
+case "$1" in
+  start)
+        log_daemon_msg "Starting $DESC" "$NAME"
+        start-stop-daemon --start --quiet --user $RUN_AS_USER --pidfile /var/run/$NAME.pid \
+                --exec $DAEMON -- $DAEMON_OPTS
+        log_end_msg $?
+        ;;
+  stop)
+        log_daemon_msg "Stopping $DESC" "$NAME"
+        start-stop-daemon --stop --oknodo --quiet --user $RUN_AS_USER --pidfile /var/run/$NAME.pid \
+                --retry 10 --exec $DAEMON
+        log_end_msg $?
+        ;;
+  force-reload)
+        # check whether $DAEMON is running. If so, restart
+        start-stop-daemon --stop --test --quiet --user $RUN_AS_USER --pidfile \
+                /var/run/$NAME.pid --exec $DAEMON \
+        && $0 restart \
+        || exit 0
+        ;;
+  restart)
+        log_daemon_msg "Restarting $DESC" "$NAME"
+        $0 stop
+        $0 start
+        ;;
+  status)
+        if [ -s /var/run/$NAME.pid ]; then
+            RUNNING=$(cat /var/run/$NAME.pid)
+            if [ -d /proc/$RUNNING ]; then
+                if [ $(readlink /proc/$RUNNING/exe) = $DAEMON ]; then
+                    log_success_msg "$NAME is running"
+                    exit 0
+                fi
+            fi
+
+            # No such PID, or executables don't match
+            log_failure_msg "$NAME is not running, but pidfile existed"
+            rm /var/run/$NAME.pid
+            exit 1
+        else
+            rm -f /var/run/$NAME.pid
+            log_failure_msg "$NAME not running"
+            exit 1
+        fi
+        ;;
+  *)
+        N=/etc/init.d/$NAME
+        log_failure_msg "Usage: $N {start|stop|restart|force-reload}"
+        exit 1
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
# Summary
On the discord f-t channel there was interest in making the rpi start ft-server on boot.  This does that.

There will be a similar pull for Carl's ft-demos

# Adds the following files-
- init.d/flaschen-taschen-server: ft-server startup script for init.d
- docs/starting-on-boot-initd.md: instructions on starting an ft-server on boot

# Tests
Manually tested via cli and then rebooting, and it works on Noisebridge's f-t rpi.

# Outstanding issues
There currently seems to be a flaw in that stopping the server isn't working.  I haven't spent much time on that problem, seems to be a problem with how `start-stop-daemon` deals with $DAEMON.  Like, maybe that should be a single filename, rather than a whole pathname.  Will return to it in the coming weeks.
